### PR TITLE
Repo polish: README, LICENSE, requirements, code cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ivan Verbovoy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Real-time training monitor for [Parameter Golf](https://github.com/openai/parame
 ## Quick Start
 
 ```bash
-pip install fastapi uvicorn
-python3 dashboard.py --ssh "root@host -p 1234" --remote-log LATEST
+pip install -r requirements.txt
+python3 dashboard.py --ssh "root@host -p 1234"
 ```
 
-Open `http://localhost:8050`. Replace `root@host -p 1234` with your RunPod TCP SSH connection string.
+Open the URL printed to stdout (includes auth token). Replace `root@host -p 1234` with your RunPod TCP SSH connection string.
 
 No changes to your training script needed — the dashboard parses standard `train_gpt.py` output.
 
@@ -19,29 +19,59 @@ No changes to your training script needed — the dashboard parses standard `tra
 
 ```bash
 # Monitor remote RunPod pod (auto-detects latest .log in /workspace/)
-python3 dashboard.py --ssh "root@host -p 1234" --remote-log LATEST
+python3 dashboard.py --ssh "root@host -p 1234"
 
 # Monitor specific log file on remote pod
 python3 dashboard.py --ssh "root@host -p 1234" --remote-log /workspace/train.log
 
+# Monitor multiple pods simultaneously
+python3 dashboard.py --ssh "root@pod1 -p 1234" --ssh "root@pod2 -p 5678"
+
 # View local log file
 python3 dashboard.py train.log
 
-# Open empty UI, connect to pod via browser input field
-python3 dashboard.py
+# Compare two runs (overlay on chart)
+python3 dashboard.py train.log --compare baseline.log
+
+# Custom baseline reference line on chart
+python3 dashboard.py train.log --baseline 1.10
 
 # Auto-stop pod when training completes (saves log locally first)
-python3 dashboard.py --ssh "root@host -p 1234" --remote-log LATEST \
-  --auto-stop --save-dir ./logs
+python3 dashboard.py --ssh "root@host -p 1234" --auto-stop --save-dir ./logs
 
-# Custom port
-python3 dashboard.py --port 3000
+# Discord/Slack notifications on completion or BPB threshold
+python3 dashboard.py --ssh "root@host -p 1234" \
+  --notify-webhook https://discord.com/api/webhooks/... \
+  --notify-threshold 1.10
+
+# Custom host and port
+python3 dashboard.py --host 0.0.0.0 --port 3000
 ```
+
+You can also upload `.log` files via the **+** button in the browser, or drag & drop them onto the page.
+
+## CLI Reference
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `logs` (positional) | — | Local `.log` files to display |
+| `--ssh` | — | SSH connection string (repeatable for multi-pod) |
+| `--remote-log` | `LATEST` | Log path on remote host |
+| `--compare` | — | Comparison log files (overlay on chart) |
+| `--baseline` | auto | BPB baseline reference line (auto-derives from first val_bpb if unset) |
+| `--host` | `127.0.0.1` | Bind address |
+| `--port` | `8050` | Server port |
+| `--refresh` | `180` | Auto-refresh interval in seconds |
+| `--auto-stop` | off | Save log and stop RunPod pod when training completes |
+| `--save-dir` | `.` | Directory to save logs on auto-stop |
+| `--notify-webhook` | — | Discord/Slack webhook URL for notifications |
+| `--notify-threshold` | — | Send notification when BPB crosses below this value |
+| `--insecure-host-key` | off | Use `StrictHostKeyChecking=no` (not recommended) |
 
 ## What It Shows
 
 ### During Training
-- Val BPB chart with baseline reference line (1.2244, configurable)
+- Val BPB chart with baseline reference line (configurable via `--baseline`)
 - Step count, current BPB, speed (ms/step)
 - Progress bar counting down from max wallclock (10 min default)
 - Warmup detection
@@ -63,19 +93,56 @@ python3 dashboard.py --port 3000
 
 Only stages present in the log are shown — works with any eval pipeline.
 
+### Crash Detection
+
+Automatically detects OOM errors, tracebacks, and killed processes. Shows the error excerpt in the UI and sets the progress bar to red.
+
+### SSH Health
+
+When monitoring via SSH, a status pill shows connection health:
+- Green — connected and fetching
+- Amber — stale (2+ consecutive failures)
+- Red — failing (5+ consecutive failures), shows error text
+
+### Charts
+
+All chart lines are monochrome (matching the current theme) with different dash styles (solid, dash, dot, dashdot) to distinguish runs. Primary run is full opacity, overlays are dimmed.
+
 ### Themes
-Click the logo to cycle: **mono** (black/white) → **kitty** (pink/black) → **emerald** (green/peach). Each theme has its own font, chart colors, and progress bar style. Preference saved to localStorage.
+Click the logo to cycle: **dark** (default) → **kitty** (pink/black) → **emerald** (green/peach). Each theme has its own font and chart colors. Preference saved to localStorage.
 
 ### LATEST Mode
-`--remote-log LATEST` finds the most recently modified `.log` in `/workspace/`. When a new run starts, the dashboard switches to it automatically — no restart needed.
+`--remote-log LATEST` (the default) finds the most recently modified `.log` in `/workspace/`. When a new run starts, the dashboard switches to it automatically — no restart needed.
 
 ### Auto-stop
-With `--auto-stop`, the dashboard saves the log locally and stops the RunPod pod when training completes. Requires [runpodctl](https://github.com/runpod/runpodctl) installed locally. Useful for overnight runs.
+With `--auto-stop`, the dashboard saves the log locally and stops the RunPod pod when training completes. The pod is matched by SSH host IP — never stops the wrong pod. Requires [runpodctl](https://github.com/runpod/runpodctl) installed locally.
+
+## API
+
+All endpoints (except `/healthz`) require `?token=` parameter. The token is generated on startup and printed to stdout.
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/` | GET | no | Dashboard UI (token embedded in page) |
+| `/api/data` | GET | yes | All run data + config |
+| `/api/upload` | POST | yes | Upload a `.log` file (max 50 MB) |
+| `/api/remove` | POST | yes | Remove a run by key |
+| `/api/log` | GET | yes | Raw log text (plain text) |
+| `/healthz` | GET | no | Health check: version, uptime, SSH status |
+
+## Security
+
+- Binds to `127.0.0.1` by default — only accessible from your machine
+- Auth token required on all data endpoints
+- No shell interpolation — all SSH commands use argv lists
+- Upload filenames sanitized server-side
+- SSH host key verification enabled (`StrictHostKeyChecking=accept-new`)
+- XSS prevention via DOM API (no `innerHTML` with user data)
 
 ## Requirements
 
 - Python 3.10+
-- `fastapi`, `uvicorn` (`pip install fastapi uvicorn`)
+- `fastapi`, `uvicorn`, `python-multipart` (`pip install -r requirements.txt`)
 - Internet for CDN (Plotly.js, Google Fonts) on first page load
 - SSH access to remote pod (optional, for remote monitoring)
 
@@ -102,10 +169,10 @@ Unrecognized lines are silently ignored — safe to use with any fork or modifie
 ## Tips
 
 - Use the **TCP SSH** connection from RunPod (not the proxy one), e.g. `root@203.0.113.1 -p 12345`
-- Baseline value is configurable: edit `const BASELINE=1.2244` at the top of the `<script>` section
-- Refresh rate: 10s for short runs (≤10min), 3min for long runs — auto-detected
+- Refresh rate: 10s for short runs, 3min for long runs — auto-detected
 - If SSH drops, dashboard shows cached data until reconnection
+- Logs are fetched incrementally (`tail -c`) to minimize bandwidth on long runs
 
-## Architecture
+## License
 
-Single `dashboard.py` file (~1200 lines). FastAPI backend, inline HTML/CSS/JS frontend with Plotly.js. No build step, no dependencies beyond FastAPI.
+MIT

--- a/dashboard.py
+++ b/dashboard.py
@@ -24,15 +24,18 @@ import re
 import secrets
 import shlex
 import subprocess
+import threading
 import time
+import urllib.request
 from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+import uvicorn
 
 __version__ = "0.2.0"
 _start_ts = time.time()
-
-from fastapi import FastAPI, UploadFile, File
-from fastapi.responses import HTMLResponse, JSONResponse
-import uvicorn
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB
 
 # ---------------------------------------------------------------------------
 # State
@@ -171,8 +174,6 @@ def parse_log(text: str) -> dict:
         m = re.search(r"swa: averaging (\d+) checkpoints", line)
         if m:
             d["swa_count"] = int(m.group(1))
-        if "stopping_early" in line or "step:" in line and f"/{d['config'].get('iterations', 0)}" in line:
-            pass  # status updated below
         if "peak memory" in line:
             d["peak_mem"] = line.strip()
         if "Serialized model int" in line:
@@ -242,6 +243,13 @@ def _extract_ssh_host(ssh_args: list[str]) -> str | None:
 _SAFE_LOG_PATH = re.compile(r"^/[\w./_-]+\.log$")
 
 
+def _cache_path() -> Path:
+    """Return a secure cache file path under ~/.pgolf_cache/."""
+    d = Path.home() / ".pgolf_cache"
+    d.mkdir(mode=0o700, exist_ok=True)
+    return d / "ssh_cache.log"
+
+
 def _fetch_ssh_target(target: dict) -> str:
     """Fetch log from a single SSH target with incremental tailing and health tracking."""
     ssh_args = target["ssh_args"]
@@ -293,7 +301,7 @@ def _fetch_ssh_target(target: dict) -> str:
             health["status"] = "ok"
             result = target["local_cache"]
             if result:
-                Path("/tmp/pgolf_ssh_cache.log").write_text(result)
+                _cache_path().write_text(result)
             return result
         else:
             # stat failed — fallback to full cat
@@ -307,7 +315,7 @@ def _fetch_ssh_target(target: dict) -> str:
                 health["consecutive_failures"] = 0
                 health["last_error"] = ""
                 health["status"] = "ok"
-                Path("/tmp/pgolf_ssh_cache.log").write_text(r.stdout)
+                _cache_path().write_text(r.stdout)
                 return r.stdout
             raise RuntimeError(f"cat failed: rc={r.returncode}")
     except Exception as e:
@@ -319,7 +327,7 @@ def _fetch_ssh_target(target: dict) -> str:
         elif cf >= 2:
             health["status"] = "stale"
     # Fallback: local cache file
-    cache = Path("/tmp/pgolf_ssh_cache.log")
+    cache = _cache_path()
     if cache.exists():
         t = cache.read_text()
         target["local_cache"] = t
@@ -347,7 +355,6 @@ def _send_webhook(run_data: dict, event: str):
     """Send notification to Discord/Slack webhook."""
     if not _config.get("webhook_url"):
         return
-    import urllib.request
     finals = run_data.get("finals", {})
     best_bpb = finals.get("hedge") or finals.get("sliding") or finals.get("roundtrip") or "N/A"
     artifact_mb = f'{finals["artifact_bytes"]/1e6:.2f} MB' if "artifact_bytes" in finals else "N/A"
@@ -430,7 +437,6 @@ def load_all_runs():
 
 def _auto_stop(log_text: str, parsed: dict):
     """Save log locally and stop the RunPod pod matching our SSH target."""
-    import threading
     _config["auto_stop_done"] = True
 
     # Verify all expected eval stages completed (not just a substring match)
@@ -497,7 +503,6 @@ app = FastAPI()
 
 def _check_token(token: str | None):
     """Verify auth token. Raises 403 if invalid."""
-    from fastapi import HTTPException
     if token != _auth_token:
         raise HTTPException(status_code=403, detail="Invalid or missing token")
 
@@ -529,7 +534,10 @@ def api_data(token: str = None):
 @app.post("/api/upload")
 async def upload_log(file: UploadFile = File(...), token: str = None):
     _check_token(token)
-    text = (await file.read()).decode("utf-8", errors="replace")
+    raw = await file.read()
+    if len(raw) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail=f"File too large (max {MAX_UPLOAD_BYTES // 1024 // 1024} MB)")
+    text = raw.decode("utf-8", errors="replace")
     data = parse_log(text)
     raw_name = Path(file.filename or "uploaded").name
     name = re.sub(r"[^\w.\-]", "_", raw_name)[:128]
@@ -1455,7 +1463,6 @@ def get_log(token: str = None):
             if p.exists():
                 text = p.read_text()
                 break
-    from fastapi.responses import PlainTextResponse
     return PlainTextResponse(text or "no log available", media_type="text/plain")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart


### PR DESCRIPTION
## Summary

- **README** rewritten: full CLI reference table, all new features documented (multi-SSH, webhooks, --baseline, /healthz, crash detection, incremental tail, upload UI), API endpoints table, security section, fixed theme name (dark not mono)
- **MIT LICENSE** added
- **requirements.txt** added (fastapi, uvicorn, python-multipart)
- **SSH cache** moved from world-readable `/tmp/` to `~/.pgolf_cache/` (mode 700)
- **Upload size limit** — 50 MB max, returns 413 if exceeded
- **Dead code removed** — `stopping_early` pass block that did nothing
- **Inline imports** moved to module level (threading, urllib.request, HTTPException, PlainTextResponse)

## Test plan

- [x] 38/38 tests passing
- [x] Syntax verified
- [ ] Verify `~/.pgolf_cache/` created with correct permissions on SSH use